### PR TITLE
[Fix]ログイン前に猫詳細に遷移できないように変更、リンクの色変更、aboutのバグ修正

### DIFF
--- a/app/controllers/public/cats_controller.rb
+++ b/app/controllers/public/cats_controller.rb
@@ -1,5 +1,5 @@
 class Public::CatsController < ApplicationController
-  before_action :authenticate_end_user!, except: :show
+  before_action :authenticate_end_user!
   before_action :find_cat, only: [:show, :edit, :update]
   before_action :permit_only_oneself, only: [:edit, :update]
   before_action :cannot_show_deleted_end_user, only: :show

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -48,7 +48,7 @@ body {
 }
 
 a {
-  color: rgba(128, 66, 66, 1.0);
+  color: rgba(50, 140, 255, 1.0);
 }
 
 .table {

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -36,4 +36,5 @@
     </div>
   </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/protonet-jquery.inview/1.1.2/jquery.inview.min.js"></script>
 <%= javascript_include_tag "public-about" %>


### PR DESCRIPTION
ログイン前に猫の詳細ページに遷移できるようにしていたが、bookmarkボタンでログインしているユーザーに対してown_catsメソッドを使っていたので、エラーが生じていた。
→ログイン前に遷移できなくした。

リンクと普通のテキストの色を同じにしていたため、カーソルを合わせないと見分けがつかなかった
→aタグの色を変更した。

aboutページでリロードすると動きが表れず、何も表示されなかった。
→aboutページのjavascriptを読み込んでいる記述の上にjquery.inviewのcdnの記述を忘れていたので追加したところ、上記問題を解決できた。